### PR TITLE
fix load static for django 3 compability

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -1,12 +1,12 @@
-from fabric.api import local, run, cd
-from fabric.state import output
 import totalsum
+from fabric.api import cd, local, run
+from fabric.state import output
 
 
 def publish(message):
     v = totalsum.__version__
 
-    output['everything'] = True
+    output["everything"] = True
     local("git pull")
     try:
         local("git add -A")

--- a/setup.py
+++ b/setup.py
@@ -1,19 +1,17 @@
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
+
 import totalsum
 
-setup(name='django-totalsum-admin',
-      version=totalsum.__version__,
-      description='A django app that initializes admin changelist view with last row in results as sum of some numerical fields or properties',
-      author='20tab S.r.l.',
-      author_email='info@20tab.com',
-      url='https://github.com/20tab/django-totalsum-admin',
-      license='MIT License',
-      install_requires=[
-          'Django >=1.6',
-      ],
-      packages=find_packages(),
-      include_package_data=True,
-      package_data={
-          '': ['*.html', '*.css', '*.js', '*.gif', '*.png', ],
-      }
+setup(
+    name="django-totalsum-admin",
+    version=totalsum.__version__,
+    description="A django app that initializes admin changelist view with last row in results as sum of some numerical fields or properties",
+    author="20tab S.r.l.",
+    author_email="info@20tab.com",
+    url="https://github.com/20tab/django-totalsum-admin",
+    license="MIT License",
+    install_requires=["Django >=3.0",],
+    packages=find_packages(),
+    include_package_data=True,
+    package_data={"": ["*.html", "*.css", "*.js", "*.gif", "*.png",],},
 )

--- a/totalsum/__init__.py
+++ b/totalsum/__init__.py
@@ -1,3 +1,3 @@
-VERSION = (1, 0, 0)
-__version__ = '.'.join(map(str, VERSION))
-DATE = "2019-04-20"
+VERSION = (2, 0, 0)
+__version__ = ".".join(map(str, VERSION))
+DATE = "2020-02-28"

--- a/totalsum/admin.py
+++ b/totalsum/admin.py
@@ -5,35 +5,39 @@ from django.db.models.fields import FieldDoesNotExist
 
 
 class TotalsumAdmin(admin.ModelAdmin):
-    change_list_template = 'totalsum_change_list.html'
+    change_list_template = "totalsum_change_list.html"
 
     totalsum_list = ()
-    unit_of_measure = ''
+    unit_of_measure = ""
     totalsum_decimal_places = 2
 
     def changelist_view(self, request, extra_context=None):
         response = super(TotalsumAdmin, self).changelist_view(request, extra_context)
-        if not hasattr(response, 'context_data') or 'cl' not in response.context_data:
+        if not hasattr(response, "context_data") or "cl" not in response.context_data:
             return response
         filtered_query_set = response.context_data["cl"].queryset
         extra_context = extra_context or {}
-        extra_context['totals'] = {}
-        extra_context['unit_of_measure'] = self.unit_of_measure
+        extra_context["totals"] = {}
+        extra_context["unit_of_measure"] = self.unit_of_measure
 
         for elem in self.totalsum_list:
             try:
                 self.model._meta.get_field(elem)  # Checking if elem is a field
-                total = filtered_query_set.aggregate(totalsum_field=Sum(elem))['totalsum_field']
+                total = filtered_query_set.aggregate(totalsum_field=Sum(elem))[
+                    "totalsum_field"
+                ]
                 if total is not None:
-                    extra_context['totals'][label_for_field(elem, self.model, self)] = round(
-                        total, self.totalsum_decimal_places)
+                    extra_context["totals"][
+                        label_for_field(elem, self.model, self)
+                    ] = round(total, self.totalsum_decimal_places)
             except FieldDoesNotExist:  # maybe it's a property
                 if hasattr(self.model, elem):
                     total = 0
                     for f in filtered_query_set:
                         total += getattr(f, elem, 0)
-                    extra_context['totals'][label_for_field(elem, self.model, self)] = round(
-                        total, self.totalsum_decimal_places)
+                    extra_context["totals"][
+                        label_for_field(elem, self.model, self)
+                    ] = round(total, self.totalsum_decimal_places)
 
         response.context_data.update(extra_context)
         return response

--- a/totalsum/templates/totalsum_change_list_results.html
+++ b/totalsum/templates/totalsum_change_list_results.html
@@ -1,4 +1,4 @@
-{% load i18n admin_static %}
+{% load i18n static %}
 {% load totalsum %}
 {% if result_hidden_fields %}
 <div class="hiddenfields">{# DIV for HTML validation #}

--- a/totalsum/templatetags/totalsum.py
+++ b/totalsum/templatetags/totalsum.py
@@ -1,9 +1,13 @@
 """
 Contains some common filter as utilities
 """
+from django.contrib.admin.templatetags.admin_list import (
+    admin_actions,
+    result_headers,
+    result_hidden_fields,
+    results,
+)
 from django.template import Library, loader
-from django.contrib.admin.templatetags.admin_list import result_headers, result_hidden_fields, results, admin_actions
-
 
 register = Library()
 
@@ -11,23 +15,29 @@ admin_actions = admin_actions
 
 
 @register.simple_tag(takes_context=True)
-def totalsum_result_list(context, cl, totals, unit_of_measure, template_name="totalsum_change_list_results.html"):
+def totalsum_result_list(
+    context,
+    cl,
+    totals,
+    unit_of_measure,
+    template_name="totalsum_change_list_results.html",
+):
 
     pagination_required = (not cl.show_all or not cl.can_show_all) and cl.multi_page
     headers = list(result_headers(cl))
     num_sorted_fields = 0
     for h in headers:
-        if h['sortable'] and h['sorted']:
+        if h["sortable"] and h["sorted"]:
             num_sorted_fields += 1
     c = {
-        'cl': cl,
-        'totals': totals,
-        'unit_of_measure': unit_of_measure,
-        'result_hidden_fields': list(result_hidden_fields(cl)),
-        'result_headers': headers,
-        'num_sorted_fields': num_sorted_fields,
-        'results': list(results(cl)),
-        'pagination_required': pagination_required
+        "cl": cl,
+        "totals": totals,
+        "unit_of_measure": unit_of_measure,
+        "result_hidden_fields": list(result_hidden_fields(cl)),
+        "result_headers": headers,
+        "num_sorted_fields": num_sorted_fields,
+        "results": list(results(cl)),
+        "pagination_required": pagination_required,
     }
 
     t = loader.get_template(template_name)
@@ -38,4 +48,4 @@ def totalsum_result_list(context, cl, totals, unit_of_measure, template_name="to
 def get_total(totals, column):
     if column in totals.keys():
         return totals[column]
-    return ''
+    return ""


### PR DESCRIPTION
{% load staticfiles %} and {% load admin_static %} were deprecated in Django 2.1, and removed in Django 3.0.

If you have any of the following in your template:

{% load staticfiles %}
{% load static from staticfiles %}
{% load admin_static %}
You should replace the tag with simply:

{% load static %}

Applied black and flake8