### PR TITLE
Fix TypeError when calculating totals from functions in models

### DIFF
--- a/totalsum/admin.py
+++ b/totalsum/admin.py
@@ -34,7 +34,14 @@ class TotalsumAdmin(admin.ModelAdmin):
                 if hasattr(self.model, elem):
                     total = 0
                     for f in filtered_query_set:
-                        total += getattr(f, elem, 0)
+                        try:
+                            total += getattr(f, elem, 0)
+                        except TypeError:
+                            # This allows calculating totals of columns
+                            # that are generated from functions in the model
+                            # by simply calling the function reference that 
+                            # getattr returns 
+                            total += getattr(f, elem, 0)()
                     extra_context["totals"][
                         label_for_field(elem, self.model, self)
                     ] = round(total, self.totalsum_decimal_places)


### PR DESCRIPTION
If you try to calculate the total of a column that is actually a function declared in the model and not a simple field, you get a “TypeError: unsupported operand type(s) for +=: 'int' and 'method'” on line 37. Simply catching the TypeError and calling the ‘getattr’ function with an additional set of brackets fixes this.