### PR TITLE
Improve total output.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,11 @@ Use the following command: <b><i>pip install django-totalsum-admin</i></b>
 
 ```py
 INSTALLED_APPS = {
-    ...,
+    # ...,
+    'django.contrib.humanize',
+    # ...,
     'totalsum',
-    ...
+    # ...,
 }
 ```
 

--- a/totalsum/templates/totalsum_change_list_results.html
+++ b/totalsum/templates/totalsum_change_list_results.html
@@ -50,10 +50,10 @@
 <tr class="totals">
 {% for header in result_headers %}
     {% with header.text as header_text %}
-    <td>
         {% if totals|get_total:header_text != '' %}
         {{ totals|get_total:header_text }} {{ unit_of_measure|safe }}
         {% endif %}
+    <td style="white-space: nowrap;">
     </td>
     {% endwith %}
 {% endfor %}

--- a/totalsum/templates/totalsum_change_list_results.html
+++ b/totalsum/templates/totalsum_change_list_results.html
@@ -1,4 +1,4 @@
-{% load i18n static %}
+{% load humanize i18n static %}
 {% load totalsum %}
 {% if result_hidden_fields %}
 <div class="hiddenfields">{# DIV for HTML validation #}
@@ -50,10 +50,12 @@
 <tr class="totals">
 {% for header in result_headers %}
     {% with header.text as header_text %}
-        {% if totals|get_total:header_text != '' %}
-        {{ totals|get_total:header_text }} {{ unit_of_measure|safe }}
-        {% endif %}
     <td style="white-space: nowrap;">
+        {% with totals|get_total:header_text as total %}
+            {% if total %}
+                {{ total|intcomma }} {{ unit_of_measure|safe }}
+            {% endif %}
+        {% endwith %}
     </td>
     {% endwith %}
 {% endfor %}


### PR DESCRIPTION
This PR contains two improvements:
- Fix unit of measure on new line when the total column width is not enough.
- Format total by adding thousands separator using `humanize.intcomma`.

Before:
<img width="1190" alt="total-before" src="https://user-images.githubusercontent.com/1035294/185074195-68f311a5-9f6b-4433-8c73-407ed2a97407.png">

After:
<img width="1190" alt="total-after" src="https://user-images.githubusercontent.com/1035294/185074239-5fe05297-0eff-45eb-86a3-91c7232fe6e6.png">

